### PR TITLE
artifact signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ jobs:
         with:
           version: latest
           args: release --rm-dist
+          key: ${{ secrets.YOUR_PRIVATE_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -51,6 +52,20 @@ Following inputs can be used as `step.with` keys
 |---------------|---------|-----------|------------------------------------------|
 | `version`     | String  | `latest`  | GoReleaser version. Example: `v0.117.0`  |
 | `args`        | String  |           | Arguments to pass to GoReleaser          |
+| `key`         | String  |           | Private key to import
+
+### Signing
+
+If signing is enabled in your GoReleaser configuration, populate the `key` input with your private key
+and reference the key in your signing configuration, e.g.
+
+```
+signs:
+  - artifacts: checksum
+    args: ["--batch", "-u", "<key id, fingerprint, email, ...>", "--output", "${signature}", "--detach-sign", "${artifact}"]
+```
+
+This feature is currently only compatible when using the default `gpg` command and a private key without a passphrase.
 
 ## 🤝 How can I help ?
 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
     default: 'latest'
   args:
     description: 'Arguments to pass to GoReleaser'
+  key:
+    description: 'Private key to import'
 
 runs:
   using: 'node12'

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,11 +19,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const installer = __importStar(require("./installer"));
 const core = __importStar(require("@actions/core"));
 const exec = __importStar(require("@actions/exec"));
+const fs = __importStar(require("fs"));
 function run(silent) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const version = core.getInput('version') || 'latest';
             const args = core.getInput('args');
+            const key = core.getInput('key');
             const goreleaser = yield installer.getGoReleaser(version);
             let snapshot = '';
             if (!process.env.GITHUB_REF ||
@@ -35,6 +37,14 @@ function run(silent) {
             }
             else {
                 console.log(`✅ ${process.env.GITHUB_REF.split('/')[2]} tag found`);
+            }
+            if (key) {
+                console.log('🔑 Importing signing key...');
+                let path = `${process.env.HOME}/key.asc`;
+                fs.writeFileSync(path, key, { mode: 0o600 });
+                yield exec.exec('gpg', ['--import', path], {
+                    silent: silent
+                });
             }
             console.log('🏃 Running GoReleaser...');
             yield exec.exec(`${goreleaser} ${args}${snapshot}`, undefined, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,13 @@
 import * as installer from './installer';
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
+import * as fs from 'fs';
 
 export async function run(silent?: boolean) {
   try {
     const version = core.getInput('version') || 'latest';
     const args = core.getInput('args');
+    const key = core.getInput('key');
     const goreleaser = await installer.getGoReleaser(version);
 
     let snapshot = '';
@@ -19,6 +21,15 @@ export async function run(silent?: boolean) {
       }
     } else {
       console.log(`✅ ${process.env.GITHUB_REF!.split('/')[2]} tag found`);
+    }
+
+    if (key) {
+      console.log('🔑 Importing signing key...');
+      let path = `${process.env.HOME}/key.asc`;
+      fs.writeFileSync(path, key, {mode: 0o600})
+      await exec.exec('gpg', ['--import', path], {
+        silent: silent
+      })
     }
 
     console.log('🏃 Running GoReleaser...');


### PR DESCRIPTION
This PR adds a `key` input for use with GoReleaser's signing feature. The README and Action configuration are also updated accordingly.

When signing is enabled in the GoReleaser configuration, the `key` input can be populated with a `gpg` private key block which will be imported before running GoReleaser. The GoReleaser `signs.args` section should be modified to reference the key, e.g.

```
signs:
  - artifacts: checksum
    args: ["--batch", "-u", "<key id, fingerprint, email, ...>", "--output", "${signature}", "--detach-sign", "${artifact}"]
```

This is currently only compatible when using the default `gpg` command and a private key without a passphrase. Also, only a single public key is supported.

I'm new to TypeScript and also haven't used GPG in a few years so feedback is very welcome. This was the bare minimum to get signing working for a project of mine, but has a lot of caveats as described above.

Thanks for putting this together!