### PR TITLE
chore: Dependabot v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,7 @@ updates:
       time: "06:00"
       timezone: "Europe/Paris"
     labels:
-      - ":game_die: dependencies"
-      - ":robot: bot"
+      - "dependencies"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -18,5 +17,4 @@ updates:
     allow:
       - dependency-type: "production"
     labels:
-      - ":game_die: dependencies"
-      - ":robot: bot"
+      - "dependencies"


### PR DESCRIPTION
See https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

I think it would nice to include Dependabot v2 on main repo too :)