### PR TITLE
docs: Upgrade import GPG action version

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ the [Import GPG](https://github.com/crazy-max/ghaction-import-gpg) GitHub Action
       -
         name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
The mentioned `crazy-max/ghaction-import-gpg@v6` action is deprecated because of an old node version:

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: 
crazy-max/ghaction-import-gpg@v6. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
```

[`ghaction-import-gpg@v7`](https://github.com/crazy-max/ghaction-import-gpg/releases/tag/v7.0.0) resolves that, you have upgraded this in the CI already via dependabot but not in the docs: #546