### PR TITLE
ci: drop pre-cosign-v3 goreleaser versions from tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,7 @@ jobs:
           - windows-latest
         version:
           - latest
-          - '~> 2.6'
-          - '~> 1.26'
+          - '~> 2.13'
         distribution:
           - goreleaser
           - goreleaser-pro
@@ -74,8 +73,7 @@ jobs:
       matrix:
         version:
           - latest
-          - '~> 2.6'
-          - '~> 1.26'
+          - '~> 2.13'
         distribution:
           - goreleaser
           - goreleaser-pro

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ action will additionally verify the cosign sigstore signature of the
 checksums file against the GoReleaser release workflow's OIDC identity. If
 `cosign` isn't installed, this step is silently skipped.
 
+> **Note**: cosign signature verification requires GoReleaser **v2.13.0 or
+> newer** (and the matching `nightly`). Earlier releases ship a `.sig`
+> detached signature signed with cosign v2, which is not compatible with
+> the cosign v3 sigstore-bundle format the action verifies. For older
+> versions the cosign step is silently skipped — only the `checksums.txt`
+> SHA-256 verification runs.
+
 To enable signature verification, install cosign before running the action:
 
 ```yaml
@@ -106,8 +113,8 @@ To enable signature verification, install cosign before running the action:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-Both checksum and signature verification work for tagged releases and the
-`nightly` channel.
+Both checksum and signature verification work for tagged releases (≥ v2.13.0)
+and the `nightly` channel.
 
 ### Run on new tag
 

--- a/__tests__/goreleaser.test.ts
+++ b/__tests__/goreleaser.test.ts
@@ -6,33 +6,18 @@ import * as io from '@actions/io';
 import * as goreleaser from '../src/goreleaser';
 
 describe('install', () => {
-  it('acquires v0.182.0 version of GoReleaser', async () => {
-    const bin = await goreleaser.install('goreleaser', 'v0.182.0');
-    expect(fs.existsSync(bin)).toBe(true);
-  }, 100000);
-
   it('acquires latest version of GoReleaser', async () => {
     const bin = await goreleaser.install('goreleaser', 'latest');
     expect(fs.existsSync(bin)).toBe(true);
   }, 100000);
 
-  it('acquires v0.182.0-pro version of GoReleaser Pro', async () => {
-    const bin = await goreleaser.install('goreleaser-pro', 'v0.182.0-pro');
-    expect(fs.existsSync(bin)).toBe(true);
-  }, 100000);
-
-  it('acquires latest v1 version of GoReleaser', async () => {
-    const bin = await goreleaser.install('goreleaser', '~> v1');
-    expect(fs.existsSync(bin)).toBe(true);
-  }, 100000);
-
-  it('acquires latest v1 version of GoReleaser Pro', async () => {
-    const bin = await goreleaser.install('goreleaser-pro', '~> v1');
-    expect(fs.existsSync(bin)).toBe(true);
-  }, 100000);
-
   it('acquires latest v2 version of GoReleaser', async () => {
     const bin = await goreleaser.install('goreleaser', '~> v2');
+    expect(fs.existsSync(bin)).toBe(true);
+  }, 100000);
+
+  it('acquires v2.13.0 (minimum cosign-verifiable) version of GoReleaser', async () => {
+    const bin = await goreleaser.install('goreleaser', 'v2.13.0');
     expect(fs.existsSync(bin)).toBe(true);
   }, 100000);
 


### PR DESCRIPTION
GoReleaser v2.13.0 was the first release to ship the cosign v3
sigstore-bundle 'checksums.txt.sigstore.json' alongside the archive.
Earlier releases only publish a cosign v2 detached '.sig', which the
action's verifier does not understand and silently skips.

Drop '~> 1.26' / '~> 2.6' / 'v0.182.0' / '~> v1' from the matrix and
the install tests; pin '~> 2.13' as the minimum-supported version we
actively exercise in CI. Document v2.13.0 as the minimum cosign-
verifiable version in the README.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
