### PR TITLE
ci: auto-rebuild dist on dependabot PRs

### DIFF
--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -1,0 +1,70 @@
+name: rebuild-dist
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
+on:
+  pull_request:
+
+jobs:
+  # Rebuilds the bundled dist/ on Dependabot PRs and pushes it back to the PR
+  # branch, so a dependency bump and its matching dist/ land in a single PR and
+  # the validate workflow stays green.
+  #
+  # Dependabot runs get a read-only GITHUB_TOKEN, and commits pushed with it do
+  # not re-trigger checks. Pushing the dist commit therefore uses GH_PAT, which
+  # can re-run workflows. Note: Dependabot runs only expose Dependabot secrets,
+  # so GH_PAT must exist as a Dependabot secret (org or repo) with contents:write
+  # on this repo. Until it does this job is a no-op.
+  rebuild-dist:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check token
+        id: token
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -n "$GH_PAT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GH_PAT Dependabot secret is not set; skipping automatic dist rebuild."
+          fi
+      - name: Checkout
+        if: steps.token.outputs.available == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_PAT }}
+      - name: Setup Node.js
+        if: steps.token.outputs.available == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+      - name: Install dependencies
+        if: steps.token.outputs.available == 'true'
+        run: npm ci --ignore-scripts
+      - name: Rebuild dist
+        if: steps.token.outputs.available == 'true'
+        run: npm run build
+      - name: Commit and push dist if changed
+        if: steps.token.outputs.available == 'true'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ -z "$(git status --porcelain -- dist)" ]; then
+            echo "dist is already up to date."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist
+          git commit -m "build: rebuild dist"
+          git push origin "HEAD:${HEAD_REF}"


### PR DESCRIPTION
## What

Adds `.github/workflows/rebuild-dist.yml`. On **Dependabot PRs** it rebuilds the ncc-bundled `dist/` and pushes it back onto the PR branch, so a dependency bump and its matching `dist/` land in **one PR** and `validate` stays green — no separate follow-up PR.

## Why a token

Dependabot runs get a **read-only** `GITHUB_TOKEN`, and commits pushed with it don't re-trigger checks. The push uses `GH_PAT` so `validate` re-runs on the new commit. The re-trigger also means the dist commit is attributed to the PAT owner (not `dependabot[bot]`), so this job doesn't loop.

## ⚠️ Setup required

`GH_PAT` exists as an **org Actions secret**, but **Dependabot runs only see Dependabot secrets**. For this to activate, `GH_PAT` must be available as a **Dependabot** secret (org or repo) with `contents:write` on this repo.

Until then the job is a **safe no-op** (guarded on the secret being set), so merging this never breaks Dependabot PRs.

## Security

- Default token stays `contents: read`.
- `npm ci --ignore-scripts` + `ncc` only *bundles* the bumped dep (never executes it), so the PAT isn't exposed to dependency code.
- `require_last_push_approval` is `false`, so you can still approve + merge the single PR after the bot pushes `dist/`.