### PR TITLE
ci: use a GitHub App token to rebuild dist on dependabot PRs

### DIFF
--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -17,45 +17,55 @@ jobs:
   # the validate workflow stays green.
   #
   # Dependabot runs get a read-only GITHUB_TOKEN, and commits pushed with it do
-  # not re-trigger checks. Pushing the dist commit therefore uses GH_PAT, which
-  # can re-run workflows. Note: Dependabot runs only expose Dependabot secrets,
-  # so GH_PAT must exist as a Dependabot secret (org or repo) with contents:write
-  # on this repo. Until it does this job is a no-op.
+  # not re-trigger checks. Pushing the dist commit therefore uses a GitHub App
+  # token, which is repo-scoped and short-lived, and can re-run workflows.
+  # Configure a GitHub App with contents:write on this repo and set its
+  # credentials as Dependabot secrets named DIST_REBUILD_APP_ID and
+  # DIST_REBUILD_APP_PRIVATE_KEY (Dependabot runs only expose Dependabot
+  # secrets). Until both exist this job is a no-op.
   rebuild-dist:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Check token
-        id: token
+      - name: Check app credentials
+        id: app
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
+          DIST_REBUILD_APP_ID: ${{ secrets.DIST_REBUILD_APP_ID }}
+          DIST_REBUILD_APP_PRIVATE_KEY: ${{ secrets.DIST_REBUILD_APP_PRIVATE_KEY }}
         run: |
-          if [ -n "$GH_PAT" ]; then
+          if [ -n "$DIST_REBUILD_APP_ID" ] && [ -n "$DIST_REBUILD_APP_PRIVATE_KEY" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::GH_PAT Dependabot secret is not set; skipping automatic dist rebuild."
+            echo "::notice::DIST_REBUILD_APP_ID/DIST_REBUILD_APP_PRIVATE_KEY Dependabot secrets are not set; skipping automatic dist rebuild."
           fi
+      - name: Generate token
+        if: steps.app.outputs.available == 'true'
+        id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.DIST_REBUILD_APP_ID }}
+          private-key: ${{ secrets.DIST_REBUILD_APP_PRIVATE_KEY }}
       - name: Checkout
-        if: steps.token.outputs.available == 'true'
+        if: steps.app.outputs.available == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.token.outputs.token }}
       - name: Setup Node.js
-        if: steps.token.outputs.available == 'true'
+        if: steps.app.outputs.available == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.node-version'
           cache: npm
       - name: Install dependencies
-        if: steps.token.outputs.available == 'true'
+        if: steps.app.outputs.available == 'true'
         run: npm ci --ignore-scripts
       - name: Rebuild dist
-        if: steps.token.outputs.available == 'true'
+        if: steps.app.outputs.available == 'true'
         run: npm run build
       - name: Commit and push dist if changed
-        if: steps.token.outputs.available == 'true'
+        if: steps.app.outputs.available == 'true'
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |

--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -20,9 +20,9 @@ jobs:
   # not re-trigger checks. Pushing the dist commit therefore uses a GitHub App
   # token, which is repo-scoped and short-lived, and can re-run workflows.
   # Configure a GitHub App with contents:write on this repo and set its
-  # credentials as Dependabot secrets named DIST_REBUILD_APP_ID and
-  # DIST_REBUILD_APP_PRIVATE_KEY (Dependabot runs only expose Dependabot
-  # secrets). Until both exist this job is a no-op.
+  # credentials as Dependabot secrets named GORELEASER_APP_ID and
+  # GORELEASER_APP_KEY (Dependabot runs only expose Dependabot secrets).
+  # Until both exist this job is a no-op.
   rebuild-dist:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
@@ -30,22 +30,22 @@ jobs:
       - name: Check app credentials
         id: app
         env:
-          DIST_REBUILD_APP_ID: ${{ secrets.DIST_REBUILD_APP_ID }}
-          DIST_REBUILD_APP_PRIVATE_KEY: ${{ secrets.DIST_REBUILD_APP_PRIVATE_KEY }}
+          GORELEASER_APP_ID: ${{ secrets.GORELEASER_APP_ID }}
+          GORELEASER_APP_KEY: ${{ secrets.GORELEASER_APP_KEY }}
         run: |
-          if [ -n "$DIST_REBUILD_APP_ID" ] && [ -n "$DIST_REBUILD_APP_PRIVATE_KEY" ]; then
+          if [ -n "$GORELEASER_APP_ID" ] && [ -n "$GORELEASER_APP_KEY" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::DIST_REBUILD_APP_ID/DIST_REBUILD_APP_PRIVATE_KEY Dependabot secrets are not set; skipping automatic dist rebuild."
+            echo "::notice::GORELEASER_APP_ID/GORELEASER_APP_KEY Dependabot secrets are not set; skipping automatic dist rebuild."
           fi
       - name: Generate token
         if: steps.app.outputs.available == 'true'
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.DIST_REBUILD_APP_ID }}
-          private-key: ${{ secrets.DIST_REBUILD_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.GORELEASER_APP_ID }}
+          private-key: ${{ secrets.GORELEASER_APP_KEY }}
       - name: Checkout
         if: steps.app.outputs.available == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## What

Follow-up to #568. Switches the `rebuild-dist` workflow from `GH_PAT` to a **GitHub App token** for pushing the rebuilt `dist/` back to Dependabot PR branches.

## Why

`GH_PAT` is a broad org PAT. Exposing it on a (semi-trusted) Dependabot PR build is risky. A GitHub App token is:
- **repo-scoped** — only this repo, not the whole org,
- **minimally permissioned** — just `contents:write`,
- **short-lived** — expires in ~1h.

It still re-triggers `validate` (so the single PR goes green), and since the push is attributed to the app's bot (not `dependabot[bot]`), the job doesn't loop.

## Setup

Reuses the existing GoReleaser GitHub App via **Dependabot** secrets (Dependabot runs only see Dependabot secrets):
- `GORELEASER_APP_ID`
- `GORELEASER_APP_KEY`

The App needs **Contents: Read and write** on this repo. If those secrets aren't present on Dependabot runs, the job is a **safe no-op**.

## Security

- Default `GITHUB_TOKEN` stays `contents: read`.
- `npm ci --ignore-scripts` + `ncc` only *bundles* the bumped dep (never executes it), so the token isn't exposed to dependency code.
- Uses pinned `actions/create-github-app-token@v3.2.0`.